### PR TITLE
Add the checking for methods like isField.

### DIFF
--- a/src/main/java/br/edu/ufcg/splab/designtests/designrules/AbstractDesignRule.java
+++ b/src/main/java/br/edu/ufcg/splab/designtests/designrules/AbstractDesignRule.java
@@ -21,7 +21,17 @@ public abstract class AbstractDesignRule implements Rule {
     /**
      * ClassNode for represents the {@link Object} class.
      */
-    private final ClassNode objectClass = new ClassNode("java.lang.Object");
+    private final ClassNode OBJECT_CLASS = new ClassNode("java.lang.Object");
+
+    /**
+     * ClassNode for represents the boolean primitive type.
+     */
+    private final ClassNode BOOLEAN_PRIMITIVE = new ClassNode("boolean");
+
+    /**
+     * ClassNode for represents the {@link Boolean} class.
+     */
+    private final ClassNode BOOLEAN_CLASS = new ClassNode("java.lang.Boolean");
 
     /**
      * Facts of the Software Design.
@@ -95,7 +105,7 @@ public abstract class AbstractDesignRule implements Rule {
      * @return A ClassNode for <code>java.lang.Object</code>.
      */
     public final ClassNode getObjectClass() {
-        return this.objectClass;
+        return this.OBJECT_CLASS;
     }
 
     /**
@@ -182,7 +192,15 @@ public abstract class AbstractDesignRule implements Rule {
     protected final boolean hasGetMethod(final FieldNode fieldNode, final ClassNode entityNode) {
         String shortFieldName = fieldNode.getShortName();
         ClassNode type = fieldNode.getType();
-        String methodGetField = "get" + shortFieldName.substring(0, 1).toUpperCase()
+        String strGetOrIs = "";
+
+        if (type != null && (type.equals(BOOLEAN_PRIMITIVE) || type.equals(BOOLEAN_CLASS))) {
+            strGetOrIs = "is";
+        } else {
+            strGetOrIs = "get";
+        }
+
+        String methodGetField = strGetOrIs + shortFieldName.substring(0, 1).toUpperCase()
                 + shortFieldName.substring(1) + "()";
 
         MethodNode methodNode = entityNode.getDeclaredMethod(methodGetField);

--- a/src/test/java/tests/br/edu/ufcg/splab/designtests/entities/EntityA.java
+++ b/src/test/java/tests/br/edu/ufcg/splab/designtests/entities/EntityA.java
@@ -36,6 +36,12 @@ public class EntityA implements Serializable {
     @Column
     private String name;
 
+    @Column
+    private Boolean verified;
+
+    @Column
+    private boolean confirmed;
+
     @OneToMany(cascade = CascadeType.ALL, fetch=FetchType.LAZY)
     private Set<EntityB> entityBSet = new HashSet<EntityB>();
 
@@ -108,5 +114,21 @@ public class EntityA implements Serializable {
 
     public void setEntityESortedSet(SortedSet<EntityE> entityESortedSet) {
         this.entityESortedSet = entityESortedSet;
+    }
+
+    public void setVerified(Boolean bool) {
+        this.verified = bool;
+    }
+
+    public Boolean isVerified() {
+        return this.verified;
+    }
+
+    public void setConfirmed(boolean bool) {
+        this.verified = bool;
+    }
+
+    public boolean isConfirmed() {
+        return this.verified;
     }
 }

--- a/src/test/java/tests/br/edu/ufcg/splab/designtests/entities/EntityB.java
+++ b/src/test/java/tests/br/edu/ufcg/splab/designtests/entities/EntityB.java
@@ -27,6 +27,12 @@ public class EntityB implements Serializable {
     private String name;
 
     @Column
+    private Boolean verified;
+
+    @Column
+    private boolean confirmed;
+
+    @Column
     @ElementCollection(fetch=FetchType.EAGER)
     private List<String> collectionList;
 


### PR DESCRIPTION
Add the checking for methods like isField(). The isField() methods are
used as getMethods for boolean fields. This functionality must be
implemented in ProvideGetsSetsFieldsRule class. Update on tests for the
modifications.
